### PR TITLE
Redis Proxy: Add cluster-scope and random-shard command handling with aggregation strategies and validation

### DIFF
--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -388,11 +388,8 @@ new_features:
     phase cannot work because rate limit filter does not provide the necessary context.
 - area: redis
   change: |
-    Added support for thirty-three new Redis commands including ``COPY``, ``RPOPLPUSH``, ``SMOVE``, ``SUNION``, ``SDIFF``,
-    ``SINTER``, ``SINTERSTORE``, ``ZUNIONSTORE``, ``ZINTERSTORE``, ``PFMERGE``, ``GEORADIUS``, ``GEORADIUSBYMEMBER``,
-    ``RENAME``, ``SORT``, ``SORT_RO``, ``ZMSCORE``, ``SDIFFSTORE``, ``MSETNX``, ``SUBSTR``, ``ZRANGESTORE``, ``ZUNION``,
-    ``ZDIFF``, ``SUNIONSTORE``, ``SMISMEMBER``, ``HRANDFIELD``, ``GEOSEARCHSTORE``, ``ZDIFFSTORE``, ``ZINTER``, ``ZRANDMEMBER``,
-    ``BITOP``, ``LPOS``, ``RENAMENX``.
+    Added framework for handling commands that will be sent to all redis nodes in cluster
+    and the response receicved will be handled using appropriate response handler.
 - area: observability
   change: |
     Added ``ENVOY_NOTIFICATION`` macro to track specific conditions in production environments.

--- a/docs/root/intro/arch_overview/other_protocols/redis.rst
+++ b/docs/root/intro/arch_overview/other_protocols/redis.rst
@@ -175,6 +175,16 @@ For details on each command's usage see the official
   RENAMENX, Generic
   SORT, Generic
   SORT_RO, Generic
+  SCRIPT, Generic
+  FLUSHALL, Generic
+  FLUSHDB, Generic
+  SLOWLOG, Generic
+  CONFIG, Generic
+  CLUSTER INFO, Generic
+  CLUSTER SLOTS, Generic
+  CLUSTER KEYSLOT, Generic
+  CLUSTER NODES, Generic
+  RANDOMKEY, Generic
   GEOADD, Geo
   GEODIST, Geo
   GEOHASH, Geo

--- a/source/extensions/filters/network/common/redis/BUILD
+++ b/source/extensions/filters/network/common/redis/BUILD
@@ -56,6 +56,7 @@ envoy_cc_library(
     hdrs = ["supported_commands.h"],
     deps = [
         "//source/common/common:macros",
+        "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
     ],
 )

--- a/source/extensions/filters/network/common/redis/redis_command_stats.cc
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.cc
@@ -26,10 +26,10 @@ RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table, const std
       Extensions::NetworkFilters::Common::Redis::SupportedCommands::evalCommands());
   stat_name_set_->rememberBuiltins(Extensions::NetworkFilters::Common::Redis::SupportedCommands::
                                        hashMultipleSumResultCommands());
-  stat_name_set_->rememberBuiltins(Extensions::NetworkFilters::Common::Redis::SupportedCommands::
-                                      ClusterScopeCommands());
-  stat_name_set_->rememberBuiltins(Extensions::NetworkFilters::Common::Redis::SupportedCommands::
-                                      randomShardCommands());
+  stat_name_set_->rememberBuiltins(
+      Extensions::NetworkFilters::Common::Redis::SupportedCommands::ClusterScopeCommands());
+  stat_name_set_->rememberBuiltins(
+      Extensions::NetworkFilters::Common::Redis::SupportedCommands::randomShardCommands());
   stat_name_set_->rememberBuiltin(
       Extensions::NetworkFilters::Common::Redis::SupportedCommands::mget());
   stat_name_set_->rememberBuiltin(

--- a/source/extensions/filters/network/common/redis/redis_command_stats.cc
+++ b/source/extensions/filters/network/common/redis/redis_command_stats.cc
@@ -26,6 +26,10 @@ RedisCommandStats::RedisCommandStats(Stats::SymbolTable& symbol_table, const std
       Extensions::NetworkFilters::Common::Redis::SupportedCommands::evalCommands());
   stat_name_set_->rememberBuiltins(Extensions::NetworkFilters::Common::Redis::SupportedCommands::
                                        hashMultipleSumResultCommands());
+  stat_name_set_->rememberBuiltins(Extensions::NetworkFilters::Common::Redis::SupportedCommands::
+                                      ClusterScopeCommands());
+  stat_name_set_->rememberBuiltins(Extensions::NetworkFilters::Common::Redis::SupportedCommands::
+                                      randomShardCommands());
   stat_name_set_->rememberBuiltin(
       Extensions::NetworkFilters::Common::Redis::SupportedCommands::mget());
   stat_name_set_->rememberBuiltin(

--- a/source/extensions/filters/network/common/redis/supported_commands.cc
+++ b/source/extensions/filters/network/common/redis/supported_commands.cc
@@ -8,11 +8,38 @@ namespace Redis {
 
 bool SupportedCommands::isSupportedCommand(const std::string& command) {
   return (simpleCommands().contains(command) || evalCommands().contains(command) ||
-          hashMultipleSumResultCommands().contains(command) ||
-          transactionCommands().contains(command) || auth() == command || echo() == command ||
-          mget() == command || mset() == command || keys() == command || ping() == command ||
-          time() == command || quit() == command || select() == command || scan() == command ||
-          info() == command || role() == command);
+          hashMultipleSumResultCommands().contains(command) || ClusterScopeCommands().contains(command) ||
+          randomShardCommands().contains(command) || transactionCommands().contains(command) ||
+          auth() == command || echo() == command || mget() == command || mset() == command ||
+          keys() == command || ping() == command || time() == command || quit() == command ||
+          select() == command || scan() == command || info() == command || role() == command);
+}
+
+bool SupportedCommands::isCommandValidWithoutArgs(const std::string& command_name) {
+  // Transaction commands are valid without mandatory arguments
+  if (transactionCommands().contains(command_name)) {
+    return true;
+  }
+  
+  // Commands that are explicitly valid without mandatory arguments
+  return commandsWithoutMandatoryArgs().contains(command_name);
+}
+
+bool SupportedCommands::validateCommandSubcommands(const std::string& command,
+                                                   const std::string& subcommand) {
+  const CommandSubcommandMap& validation_map = commandSubcommandValidationMap();
+  
+  // If command is not in validation map, all subcommands are allowed
+  auto it = validation_map.find(command);
+  if (it == validation_map.end()) {
+    return true; // No validation needed - all forms of the command are supported
+  }
+  
+  // Command is in validation map, so it has subcommand restrictions
+  // Validate the subcommand against the allowlist
+  const auto& allowed_subcommands = it->second;
+  
+  return allowed_subcommands.find(subcommand) != allowed_subcommands.end();
 }
 
 } // namespace Redis

--- a/source/extensions/filters/network/common/redis/supported_commands.cc
+++ b/source/extensions/filters/network/common/redis/supported_commands.cc
@@ -8,11 +8,12 @@ namespace Redis {
 
 bool SupportedCommands::isSupportedCommand(const std::string& command) {
   return (simpleCommands().contains(command) || evalCommands().contains(command) ||
-          hashMultipleSumResultCommands().contains(command) || ClusterScopeCommands().contains(command) ||
-          randomShardCommands().contains(command) || transactionCommands().contains(command) ||
-          auth() == command || echo() == command || mget() == command || mset() == command ||
-          keys() == command || ping() == command || time() == command || quit() == command ||
-          select() == command || scan() == command || info() == command || role() == command);
+          hashMultipleSumResultCommands().contains(command) ||
+          ClusterScopeCommands().contains(command) || randomShardCommands().contains(command) ||
+          transactionCommands().contains(command) || auth() == command || echo() == command ||
+          mget() == command || mset() == command || keys() == command || ping() == command ||
+          time() == command || quit() == command || select() == command || scan() == command ||
+          info() == command || role() == command);
 }
 
 bool SupportedCommands::isCommandValidWithoutArgs(const std::string& command_name) {
@@ -20,7 +21,7 @@ bool SupportedCommands::isCommandValidWithoutArgs(const std::string& command_nam
   if (transactionCommands().contains(command_name)) {
     return true;
   }
-  
+
   // Commands that are explicitly valid without mandatory arguments
   return commandsWithoutMandatoryArgs().contains(command_name);
 }
@@ -28,17 +29,17 @@ bool SupportedCommands::isCommandValidWithoutArgs(const std::string& command_nam
 bool SupportedCommands::validateCommandSubcommands(const std::string& command,
                                                    const std::string& subcommand) {
   const CommandSubcommandMap& validation_map = commandSubcommandValidationMap();
-  
+
   // If command is not in validation map, all subcommands are allowed
   auto it = validation_map.find(command);
   if (it == validation_map.end()) {
     return true; // No validation needed - all forms of the command are supported
   }
-  
+
   // Command is in validation map, so it has subcommand restrictions
   // Validate the subcommand against the allowlist
   const auto& allowed_subcommands = it->second;
-  
+
   return allowed_subcommands.find(subcommand) != allowed_subcommands.end();
 }
 

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -72,7 +72,7 @@ struct SupportedCommands {
    * @return commands without keys which are sent to all redis shards and the responses are handled using special response handler according  to its response type
    */
   static const absl::flat_hash_set<std::string>& ClusterScopeCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "script", "flushall", "flushdb", "slowlog", "config", "unwatch");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "script", "flushall", "flushdb", "slowlog", "config");
   }
 
   /**

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -183,6 +183,36 @@ struct SupportedCommands {
     return !writeCommands().contains(command);
   }
 
+  /**
+   * @return commands that are valid without mandatory arguments beyond the command name
+   */
+  static const absl::flat_hash_set<std::string>& commandsWithoutMandatoryArgs() {
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>,
+        "ping",      // PING [message]
+        "time",      // TIME
+        "flushall",  // FLUSHALL [ASYNC]
+        "flushdb",   // FLUSHDB [ASYNC]
+        "randomkey", // RANDOMKEY
+        "quit",      // QUIT
+        "role",      // ROLE
+        "info"       // INFO [section]
+    );
+  }
+
+  /**
+   * @return true if the command can be executed without mandatory arguments beyond command name
+   */
+  static bool isCommandValidWithoutArgs(const std::string& command_name);
+
+  /**
+   * @brief Validates if a subcommand is allowed for the given command
+   * @param command the main command name (e.g., "cluster") - should be lowercase
+   * @param subcommand the subcommand to validate (e.g., "info") - should be lowercase
+   * @return true if subcommand is valid or no validation needed, false if invalid subcommand
+   */
+  static bool validateCommandSubcommands(const std::string& command, 
+                                        const std::string& subcommand);
+
   static bool isSupportedCommand(const std::string& command);
 };
 

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -69,10 +69,12 @@ struct SupportedCommands {
   }
 
   /**
-   * @return commands without keys which are sent to all redis shards and the responses are handled using special response handler according  to its response type
+   * @return commands without keys which are sent to all redis shards and the responses are handled
+   * using special response handler according  to its response type
    */
   static const absl::flat_hash_set<std::string>& ClusterScopeCommands() {
-    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "script", "flushall", "flushdb", "slowlog", "config");
+    CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>, "script", "flushall", "flushdb",
+                           "slowlog", "config");
   }
 
   /**
@@ -88,9 +90,9 @@ struct SupportedCommands {
    * If a command is in this map, only the listed subcommands are supported
    */
   static const CommandSubcommandMap& commandSubcommandValidationMap() {
-    CONSTRUCT_ON_FIRST_USE(CommandSubcommandMap, 
-      //Command name - Sub commands that are allowed
-      {{"cluster", {"info", "slots", "keyslot", "nodes"}}});
+    CONSTRUCT_ON_FIRST_USE(CommandSubcommandMap,
+                           // Command name - Sub commands that are allowed
+                           {{"cluster", {"info", "slots", "keyslot", "nodes"}}});
     // Add other commands with restricted subcommands here:
   }
 
@@ -188,14 +190,14 @@ struct SupportedCommands {
    */
   static const absl::flat_hash_set<std::string>& commandsWithoutMandatoryArgs() {
     CONSTRUCT_ON_FIRST_USE(absl::flat_hash_set<std::string>,
-        "ping",      // PING [message]
-        "time",      // TIME
-        "flushall",  // FLUSHALL [ASYNC]
-        "flushdb",   // FLUSHDB [ASYNC]
-        "randomkey", // RANDOMKEY
-        "quit",      // QUIT
-        "role",      // ROLE
-        "info"       // INFO [section]
+                           "ping",      // PING [message]
+                           "time",      // TIME
+                           "flushall",  // FLUSHALL [ASYNC]
+                           "flushdb",   // FLUSHDB [ASYNC]
+                           "randomkey", // RANDOMKEY
+                           "quit",      // QUIT
+                           "role",      // ROLE
+                           "info"       // INFO [section]
     );
   }
 
@@ -210,8 +212,7 @@ struct SupportedCommands {
    * @param subcommand the subcommand to validate (e.g., "info") - should be lowercase
    * @return true if subcommand is valid or no validation needed, false if invalid subcommand
    */
-  static bool validateCommandSubcommands(const std::string& command, 
-                                        const std::string& subcommand);
+  static bool validateCommandSubcommands(const std::string& command, const std::string& subcommand);
 
   static bool isSupportedCommand(const std::string& command);
 };

--- a/source/extensions/filters/network/common/redis/supported_commands.h
+++ b/source/extensions/filters/network/common/redis/supported_commands.h
@@ -3,10 +3,10 @@
 #include <set>
 #include <string>
 #include <vector>
-#include <unordered_map>
 
 #include "source/common/common/macros.h"
 
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 
 namespace Envoy {
@@ -16,7 +16,7 @@ namespace Common {
 namespace Redis {
 
 // Type alias for command-subcommand validation mapping
-using CommandSubcommandMap = std::unordered_map<std::string, absl::flat_hash_set<std::string>>;
+using CommandSubcommandMap = absl::flat_hash_map<std::string, absl::flat_hash_set<std::string>>;
 
 struct SupportedCommands {
   /**

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -79,6 +79,7 @@ envoy_cc_library(
         "//source/extensions/filters/network/common/redis:fault_lib",
         "//source/extensions/filters/network/common/redis:supported_commands_lib",
         "//source/extensions/filters/network/common/redis:utility_lib",
+        "@com_google_absl//absl/container:flat_hash_map",
     ],
 )
 

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -58,12 +58,12 @@ envoy_cc_library(
 envoy_cc_library(
     name = "command_splitter_lib",
     srcs = [
-        "command_splitter_impl.cc",
         "cluster_response_handler.cc",
+        "command_splitter_impl.cc",
     ],
     hdrs = [
-        "command_splitter_impl.h",
         "cluster_response_handler.h",
+        "command_splitter_impl.h",
     ],
     deps = [
         ":command_splitter_interface",

--- a/source/extensions/filters/network/redis_proxy/BUILD
+++ b/source/extensions/filters/network/redis_proxy/BUILD
@@ -57,8 +57,14 @@ envoy_cc_library(
 
 envoy_cc_library(
     name = "command_splitter_lib",
-    srcs = ["command_splitter_impl.cc"],
-    hdrs = ["command_splitter_impl.h"],
+    srcs = [
+        "command_splitter_impl.cc",
+        "cluster_response_handler.cc",
+    ],
+    hdrs = [
+        "command_splitter_impl.h",
+        "cluster_response_handler.h",
+    ],
     deps = [
         ":command_splitter_interface",
         ":conn_pool_lib",

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
@@ -156,7 +156,7 @@ void BaseClusterScopeResponseHandler::storeResponse(Common::Redis::RespValuePtr&
   }
 
   // Track errors using handler's own state
-  if (value->type() == Common::Redis::RespType::Error) {
+  if (value && value->type() == Common::Redis::RespType::Error) {
     error_count_++;
   }
 

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
@@ -121,6 +121,19 @@ void BaseClusterScopeResponseHandler::handleResponse(Common::Redis::RespValuePtr
   processAllResponses(request);
 }
 
+void BaseClusterScopeResponseHandler::handleFailure(uint32_t shard_index, 
+                                                   ClusterScopeCmdRequest& request) {
+  ENVOY_LOG(debug, "BaseClusterScopeResponseHandler: failure received for shard index: '{}'", shard_index);
+  
+  // Create an error response for the upstream failure using standard error message
+  Common::Redis::RespValuePtr error_response = 
+    Common::Redis::Utility::makeError(Response::get().UpstreamFailure);
+  
+  // Route the error response through the normal response handling flow
+  // This ensures consistent error handling logic and stats tracking
+  handleResponse(std::move(error_response), shard_index, request);
+}
+
 void BaseClusterScopeResponseHandler::storeResponse(Common::Redis::RespValuePtr&& value, 
                                                    uint32_t shard_index, 
                                                    ClusterScopeCmdRequest& request) {

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
@@ -75,7 +75,6 @@ ClusterResponseHandlerFactory::getResponseHandlerType(const std::string& command
     {"script", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
     {"flushall", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
     {"flushdb", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
-    {"unwatch", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
     {"config:set", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
     {"config:rewrite", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
     {"config:resetstat", ClusterScopeResponseHandlerType::allresponses_mustbe_same},

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
@@ -87,18 +87,19 @@ ClusterResponseHandlerFactory::getResponseHandlerType(const std::string& command
     {"slowlog:len", ClusterScopeResponseHandlerType::aggregate_all_responses},
   };
 
-  // Create key for lookup - combine command and subcommand if present
-  std::string lookup_key = command_name;
+  // First check with subcommand to see if there is a map entry
   if (!subcommand.empty()) {
-    lookup_key += ":" + subcommand;
+      auto it = command_to_handler_map.find(command_name + ":" + subcommand);
+      if (it != command_to_handler_map.end()) {
+          return it->second;
+      }
   }
 
-  // Look up the command or command:subcommand combination
-  auto it = command_to_handler_map.find(lookup_key);
+  // Fallback to command only search for getting handler type
+  auto it = command_to_handler_map.find(command_name);
   if (it != command_to_handler_map.end()) {
-    return it->second;
+      return it->second;
   }
-  
   // Default fallback - no handler found
   return ClusterScopeResponseHandlerType::response_handler_none;
 }

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.cc
@@ -1,0 +1,313 @@
+#include "source/extensions/filters/network/redis_proxy/cluster_response_handler.h"
+#include "source/extensions/filters/network/redis_proxy/command_splitter_impl.h"
+
+#include "source/common/common/logger.h"
+#include "source/extensions/filters/network/common/redis/utility.h"
+#include "absl/strings/ascii.h"
+#include "fmt/format.h"
+#include <unordered_map>
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace RedisProxy {
+namespace CommandSplitter {
+
+// Implementation of ClusterResponseHandlerFactory
+std::unique_ptr<BaseClusterScopeResponseHandler> 
+ClusterResponseHandlerFactory::createHandler(const std::string& command_name, const std::string& subcommand, uint32_t shard_count) {
+  ClusterScopeResponseHandlerType handler_type = getResponseHandlerType(command_name, subcommand);
+  
+  switch (handler_type) {
+    case ClusterScopeResponseHandlerType::allresponses_mustbe_same:
+      return std::make_unique<AllshardSameResponseHandler>(shard_count);
+    case ClusterScopeResponseHandlerType::aggregate_all_responses:
+      // Create specific aggregate handler based on command and subcommand
+      return createAggregateHandler(command_name, subcommand, shard_count);
+    default:
+      return nullptr; // No handler for this command
+  }
+}
+
+std::unique_ptr<BaseClusterScopeResponseHandler> 
+ClusterResponseHandlerFactory::createAggregateHandler(const std::string& command_name, const std::string& subcommand, uint32_t shard_count) {
+  
+  // SLOWLOG commands
+  if (command_name == "slowlog") {
+    if (subcommand == "len") {
+      return std::make_unique<IntegerSumAggregateResponseHandler>(shard_count);
+    } else if (subcommand == "get") {
+      return std::make_unique<ArrayMergeAggregateResponseHandler>(shard_count);
+    }
+  }
+  
+  // CONFIG commands
+  if (command_name == "config" && subcommand == "get") {
+    return std::make_unique<ArrayMergeAggregateResponseHandler>(shard_count);
+  }
+
+  // Default fallback - return null for unsupported commands
+  return nullptr;
+}
+
+std::unique_ptr<BaseClusterScopeResponseHandler> 
+ClusterResponseHandlerFactory::createFromRequest(const Common::Redis::RespValue& request, uint32_t shard_count) {
+  if (request.type() != Common::Redis::RespType::Array || request.asArray().empty()) {
+    return nullptr;
+  }
+
+  const std::string command_name = absl::AsciiStrToLower(request.asArray()[0].asString());
+  std::string subcommand = "";
+  
+  if (request.asArray().size() > 1) {
+    subcommand = absl::AsciiStrToLower(request.asArray()[1].asString());
+  }
+  
+  return createHandler(command_name, subcommand, shard_count);
+}
+
+ClusterScopeResponseHandlerType 
+ClusterResponseHandlerFactory::getResponseHandlerType(const std::string& command_name, const std::string& subcommand) {
+  // Based on ClusterScopeCommands: script, flushall, flushdb, slowlog, config, unwatch
+  // Note: randomkey and cluster are now handled by RandomShardRequest
+  static const std::unordered_map<std::string, ClusterScopeResponseHandlerType> command_to_handler_map = {
+    // All shards must return same response
+    {"script", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    {"flushall", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    {"flushdb", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    {"unwatch", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    {"config:set", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    {"config:rewrite", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    {"config:resetstat", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    {"slowlog:reset", ClusterScopeResponseHandlerType::allresponses_mustbe_same},
+    
+    // Aggregate responses
+    {"config:get", ClusterScopeResponseHandlerType::aggregate_all_responses},
+    {"slowlog:get", ClusterScopeResponseHandlerType::aggregate_all_responses},
+    {"slowlog:len", ClusterScopeResponseHandlerType::aggregate_all_responses},
+  };
+
+  // Create key for lookup - combine command and subcommand if present
+  std::string lookup_key = command_name;
+  if (!subcommand.empty()) {
+    lookup_key += ":" + subcommand;
+  }
+
+  // Look up the command or command:subcommand combination
+  auto it = command_to_handler_map.find(lookup_key);
+  if (it != command_to_handler_map.end()) {
+    return it->second;
+  }
+  
+  // Default fallback - no handler found
+  return ClusterScopeResponseHandlerType::response_handler_none;
+}
+
+// Implementation of BaseClusterScopeResponseHandler - Common functionality for all handlers
+void BaseClusterScopeResponseHandler::handleResponse(Common::Redis::RespValuePtr&& value, 
+                                                     uint32_t shard_index,
+                                                     ClusterScopeCmdRequest& request) {
+  ENVOY_LOG(debug, "BaseClusterScopeResponseHandler: response received for shard index: '{}'", shard_index);
+
+  // Store the response and update counters
+  storeResponse(std::move(value), shard_index, request);
+  
+  // Early return if not all responses received yet
+  if (!allResponsesReceived(request)) {
+    return;
+  }
+  
+  // Process all responses once we have them all - specific logic per handler type
+  processAllResponses(request);
+}
+
+void BaseClusterScopeResponseHandler::storeResponse(Common::Redis::RespValuePtr&& value, 
+                                                   uint32_t shard_index, 
+                                                   ClusterScopeCmdRequest& request) {
+  // Clean up the request handle - for ClusterScopeCmdRequest, shard_index == array index
+  if (shard_index < request.pending_requests_.size()) {
+    request.pending_requests_[shard_index].handle_ = nullptr;
+  }
+
+  // Resize vector if needed to accommodate the shard_index
+  if (shard_index >= pending_responses_.size()) {
+    pending_responses_.resize(shard_index + 1);
+  }
+
+  // Track errors
+  if (value->type() == Common::Redis::RespType::Error) {
+    request.error_count_++;
+  }
+  
+  // Store the response
+  pending_responses_[shard_index] = std::move(value);
+}
+
+bool BaseClusterScopeResponseHandler::allResponsesReceived(ClusterScopeCmdRequest& request) {
+  ASSERT(request.num_pending_responses_ > 0);
+  return (--request.num_pending_responses_ == 0);
+}
+
+void BaseClusterScopeResponseHandler::handleErrorResponses(ClusterScopeCmdRequest& request) {
+  request.updateStats(false);  // Update stats first for any error case
+  
+  // Find and return the first error response
+  for (auto& resp : pending_responses_) {
+    if (resp && resp->type() == Common::Redis::RespType::Error) {
+      ENVOY_LOG(debug, "Error response received: '{}'", resp->toString());
+      request.callbacks_.onResponse(std::move(resp));
+      return;
+    }
+  }
+  
+  // Should not reach here if error_count_ > 0, but handle gracefully
+  ENVOY_LOG(error, "Error count mismatch - no error response found despite error_count_ > 0");
+  request.callbacks_.onResponse(Common::Redis::Utility::makeError(fmt::format("error count mismatch")));
+}
+
+void BaseClusterScopeResponseHandler::sendErrorResponse(ClusterScopeCmdRequest& request, 
+                                                       const std::string& error_message) {
+  ENVOY_LOG(error, "ClusterScopeResponseHandler error: {}", error_message);
+  request.updateStats(false);
+  request.callbacks_.onResponse(Common::Redis::Utility::makeError(error_message));
+}
+
+void BaseClusterScopeResponseHandler::sendSuccessResponse(ClusterScopeCmdRequest& request, 
+                                                         Common::Redis::RespValuePtr&& response) {
+  ENVOY_LOG(debug, "Success response: {}", response->toString());
+  request.updateStats(true);
+  request.callbacks_.onResponse(std::move(response));
+}
+
+// Implementation of AllshardSameResponseHandler - Specific logic for same-response validation
+void AllshardSameResponseHandler::processAllResponses(ClusterScopeCmdRequest& request) {
+  // Check for empty responses (should not happen but safety first)
+  if (pending_responses_.empty()) {
+    sendErrorResponse(request, "no responses received from any shard");
+    return;
+  }
+  
+  // Handle error responses first
+  if (request.error_count_ > 0) {
+    handleErrorResponses(request);
+    return;
+  }
+  
+  // Validate all responses are the same
+  if (!areAllResponsesSame()) {
+    // Check if we have at least one response for logging
+    if (!pending_responses_.empty() && pending_responses_[0]) {
+      ENVOY_LOG(debug, "All responses not same: '{}'", pending_responses_[0]->toString());
+    } else {
+      ENVOY_LOG(debug, "All responses not same: responses are null or empty");
+    }
+    sendErrorResponse(request, "all responses not same");
+    return;
+  }
+  
+  // Success case - all responses are the same
+  sendSuccessResponse(request, std::move(pending_responses_[0]));
+}
+
+bool AllshardSameResponseHandler::areAllResponsesSame() const {
+  if (pending_responses_.empty()) {
+    return false; // Empty responses should be treated as an error condition
+  }
+
+  const Common::Redis::RespValue* first_response = pending_responses_.front().get();
+  for (const auto& response : pending_responses_) {
+    if (!response || !first_response || *(response.get()) != *first_response) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Implementation of BaseAggregateResponseHandler - Common aggregation pattern
+void BaseAggregateResponseHandler::processAllResponses(ClusterScopeCmdRequest& request) {
+  // Handle error responses first
+  if (request.error_count_ > 0) {
+    handleErrorResponses(request);
+    return;
+  }
+  
+  // Check for empty responses
+  if (pending_responses_.empty()) {
+    sendErrorResponse(request, "no responses received from any shard");
+    return;
+  }
+  
+  // Process aggregated responses - specific logic per handler type
+  processAggregatedResponses(request);
+}
+
+// Implementation of IntegerSumAggregateResponseHandler
+void IntegerSumAggregateResponseHandler::processAggregatedResponses(ClusterScopeCmdRequest& request) {
+  int64_t sum = 0;
+  for (const auto& resp : pending_responses_) {
+    if (!resp) {
+      sendErrorResponse(request, "null response received from shard");
+      return;
+    }
+    
+    if (resp->type() != Common::Redis::RespType::Integer) {
+      sendErrorResponse(request, "non-integer response received from shard");
+      return;
+    }
+    
+    try {
+      int64_t integerValue = resp->asInteger();
+      if (integerValue < 0) {
+        ENVOY_LOG(error, "Error: Negative integer value: {}", integerValue);
+        sendErrorResponse(request, "negative value received from upstream");
+        return;
+      }
+      sum += integerValue;
+    } catch (const std::exception& e) {
+      ENVOY_LOG(error, "Error converting integer: {}", e.what());
+      sendErrorResponse(request, "invalid integer response from upstream");
+      return;
+    }
+  }
+  
+  Common::Redis::RespValuePtr response = std::make_unique<Common::Redis::RespValue>();
+  response->type(Common::Redis::RespType::Integer);
+  response->asInteger() = sum;
+  sendSuccessResponse(request, std::move(response));
+}
+
+// Implementation of ArrayMergeAggregateResponseHandler
+void ArrayMergeAggregateResponseHandler::processAggregatedResponses(ClusterScopeCmdRequest& request) {
+  Common::Redis::RespValuePtr response = std::make_unique<Common::Redis::RespValue>();
+  response->type(Common::Redis::RespType::Array);
+  
+  for (const auto& resp : pending_responses_) {
+    if (!resp) {
+      sendErrorResponse(request, "null response received from shard");
+      return;
+    }
+    
+    if (resp->type() != Common::Redis::RespType::Array) {
+      sendErrorResponse(request, "non-array response received from shard");
+      return;
+    }
+    
+    try {
+      for (auto& elem : resp->asArray()) {
+        response->asArray().emplace_back(std::move(elem));
+      }
+    } catch (const std::exception& e) {
+      ENVOY_LOG(error, "Error merging array: {}", e.what());
+      sendErrorResponse(request, "error merging array responses");
+      return;
+    }
+  }
+  
+  sendSuccessResponse(request, std::move(response));
+}
+
+} // namespace CommandSplitter
+} // namespace RedisProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
@@ -43,13 +43,6 @@ public:
   void handleResponse(Common::Redis::RespValuePtr&& value, uint32_t shard_index,
                       ClusterScopeCmdRequest& request);
 
-  /**
-   * Handle a failure from a shard by converting it to an error response
-   * @param shard_index the shard that failed (same as request index)
-   * @param request the cluster scope request object (has all needed data)
-   */
-  void handleFailure(uint32_t shard_index, ClusterScopeCmdRequest& request);
-
 protected:
   // Response handler owns response tracking state
   uint32_t num_pending_responses_;

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+#include "source/common/common/logger.h"
+#include "source/extensions/filters/network/common/redis/client_impl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace NetworkFilters {
+namespace RedisProxy {
+namespace CommandSplitter {
+
+// Forward declaration to avoid circular dependency
+class ClusterScopeCmdRequest;
+
+/**
+ * Enum defining the different response handler types for cluster scope commands
+ */
+enum class ClusterScopeResponseHandlerType {
+  allresponses_mustbe_same,
+  aggregate_all_responses,
+  response_handler_none
+};
+
+/**
+ * Base class for handling responses from cluster scope commands.
+ * Implements the Template Method pattern where handleResponse() provides
+ * the common algorithm and processAllResponses() allows customization.
+ */
+class BaseClusterScopeResponseHandler {
+public:
+  virtual ~BaseClusterScopeResponseHandler() = default;
+
+  /**
+   * Handle a response from a shard
+   * @param value the response value from upstream
+   * @param shard_index the shard that sent this response (same as request index)
+   * @param request the cluster scope request object (has all needed data)
+   */
+  void handleResponse(Common::Redis::RespValuePtr&& value, uint32_t shard_index,
+                     ClusterScopeCmdRequest& request) final;
+
+protected:
+  explicit BaseClusterScopeResponseHandler(uint32_t shard_count) {
+    pending_responses_.reserve(shard_count);
+  }
+
+  // Template method pattern - derived classes implement specific processing
+  virtual void processAllResponses(ClusterScopeCmdRequest& request) = 0;
+
+  // Common helper methods available to all derived classes
+  void storeResponse(Common::Redis::RespValuePtr&& value, uint32_t shard_index, 
+                    ClusterScopeCmdRequest& request);
+  bool allResponsesReceived(ClusterScopeCmdRequest& request);
+  void sendErrorResponse(ClusterScopeCmdRequest& request, const std::string& error_message);
+  void sendSuccessResponse(ClusterScopeCmdRequest& request, Common::Redis::RespValuePtr&& response);
+
+  std::vector<Common::Redis::RespValuePtr> pending_responses_;
+
+private:
+  void handleErrorResponses(ClusterScopeCmdRequest& request);
+};
+
+/**
+ * Response handler for commands where all shards must return the same response
+ * Examples: CONFIG SET, FLUSHALL, SCRIPT FLUSH
+ */
+class AllshardSameResponseHandler : public BaseClusterScopeResponseHandler {
+public:
+  explicit AllshardSameResponseHandler(uint32_t shard_count) 
+    : BaseClusterScopeResponseHandler(shard_count) {}
+
+protected:
+  void processAllResponses(ClusterScopeCmdRequest& request) override;
+
+private:
+  bool areAllResponsesSame() const;
+};
+
+/**
+ * Base class for aggregated response handlers
+ */
+class BaseAggregateResponseHandler : public BaseClusterScopeResponseHandler {
+protected:
+  explicit BaseAggregateResponseHandler(uint32_t shard_count) 
+    : BaseClusterScopeResponseHandler(shard_count) {}
+
+  void processAllResponses(ClusterScopeCmdRequest& request) final;
+  
+  // Template method for specific aggregation logic
+  virtual void processAggregatedResponses(ClusterScopeCmdRequest& request) = 0;
+};
+
+
+/**
+ * Handler for integer sum aggregation (PUBSUB NUMPAT, SLOWLOG LEN)
+ */
+class IntegerSumAggregateResponseHandler : public BaseAggregateResponseHandler {
+public:
+  explicit IntegerSumAggregateResponseHandler(uint32_t shard_count) 
+    : BaseAggregateResponseHandler(shard_count) {}
+
+private:
+  void processAggregatedResponses(ClusterScopeCmdRequest& request) override;
+};
+
+/**
+ * Handler for array merging (CONFIG GET, SLOWLOG GET)
+ */
+class ArrayMergeAggregateResponseHandler : public BaseAggregateResponseHandler {
+public:
+  explicit ArrayMergeAggregateResponseHandler(uint32_t shard_count) 
+    : BaseAggregateResponseHandler(shard_count) {}
+
+private:
+  void processAggregatedResponses(ClusterScopeCmdRequest& request) override;
+};
+
+
+/**
+ * Factory class for creating appropriate response handlers
+ */
+class ClusterResponseHandlerFactory {
+public:
+  /**
+   * Create a response handler based on the command and subcommand
+   * @param command_name the Redis command (e.g., "config", "info")
+   * @param subcommand the Redis subcommand if applicable (e.g., "get", "set")
+   * @param shard_count the number of shards for memory pre-allocation
+   * @return unique pointer to the appropriate response handler
+   */
+  static std::unique_ptr<BaseClusterScopeResponseHandler> 
+  createHandler(const std::string& command_name, const std::string& subcommand, uint32_t shard_count);
+
+  /**
+   * Create a response handler from a Redis request
+   * @param request the incoming Redis request
+   * @param shard_count the number of shards for memory pre-allocation
+   * @return unique pointer to the appropriate response handler
+   */
+  static std::unique_ptr<BaseClusterScopeResponseHandler> 
+  createFromRequest(const Common::Redis::RespValue& request, uint32_t shard_count);
+
+private:
+  /**
+   * Create a specific aggregate response handler based on command and subcommand
+   * @param command_name the Redis command
+   * @param subcommand the Redis subcommand if applicable
+   * @param shard_count the number of shards for memory pre-allocation
+   * @return unique pointer to the appropriate aggregate response handler
+   */
+  static std::unique_ptr<BaseClusterScopeResponseHandler> 
+  createAggregateHandler(const std::string& command_name, const std::string& subcommand, uint32_t shard_count);
+
+  /**
+   * Get the response handler type for a given command and subcommand
+   * @param command_name the Redis command
+   * @param subcommand the Redis subcommand if applicable
+   * @return the appropriate response handler type
+   */
+  static ClusterScopeResponseHandlerType 
+  getResponseHandlerType(const std::string& command_name, const std::string& subcommand = "");
+};
+
+} // namespace CommandSplitter
+} // namespace RedisProxy
+} // namespace NetworkFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
@@ -41,7 +41,7 @@ public:
    * @param request the cluster scope request object (has all needed data)
    */
   void handleResponse(Common::Redis::RespValuePtr&& value, uint32_t shard_index,
-                     ClusterScopeCmdRequest& request);
+                      ClusterScopeCmdRequest& request);
 
   /**
    * Handle a failure from a shard by converting it to an error response
@@ -56,8 +56,8 @@ protected:
   uint32_t error_count_{0};
   std::vector<Common::Redis::RespValuePtr> pending_responses_;
 
-  explicit BaseClusterScopeResponseHandler(uint32_t shard_count) 
-    : num_pending_responses_(shard_count), error_count_(0) {
+  explicit BaseClusterScopeResponseHandler(uint32_t shard_count)
+      : num_pending_responses_(shard_count), error_count_(0) {
     pending_responses_.reserve(shard_count);
   }
 
@@ -65,11 +65,11 @@ protected:
   virtual void processAllResponses(ClusterScopeCmdRequest& request) = 0;
 
   // Common helper methods available to all derived classes
-  void storeResponse(Common::Redis::RespValuePtr&& value, uint32_t shard_index, 
-                    ClusterScopeCmdRequest& request);
+  void storeResponse(Common::Redis::RespValuePtr&& value, uint32_t shard_index,
+                     ClusterScopeCmdRequest& request);
   void sendErrorResponse(ClusterScopeCmdRequest& request, const std::string& error_message);
   void sendSuccessResponse(ClusterScopeCmdRequest& request, Common::Redis::RespValuePtr&& response);
-  
+
   void handleErrorResponses(ClusterScopeCmdRequest& request);
 };
 
@@ -79,8 +79,8 @@ protected:
  */
 class AllshardSameResponseHandler : public BaseClusterScopeResponseHandler {
 public:
-  explicit AllshardSameResponseHandler(uint32_t shard_count) 
-    : BaseClusterScopeResponseHandler(shard_count) {}
+  explicit AllshardSameResponseHandler(uint32_t shard_count)
+      : BaseClusterScopeResponseHandler(shard_count) {}
 
 protected:
   void processAllResponses(ClusterScopeCmdRequest& request) override;
@@ -94,23 +94,22 @@ private:
  */
 class BaseAggregateResponseHandler : public BaseClusterScopeResponseHandler {
 protected:
-  explicit BaseAggregateResponseHandler(uint32_t shard_count) 
-    : BaseClusterScopeResponseHandler(shard_count) {}
+  explicit BaseAggregateResponseHandler(uint32_t shard_count)
+      : BaseClusterScopeResponseHandler(shard_count) {}
 
   void processAllResponses(ClusterScopeCmdRequest& request) final;
-  
+
   // Template method for specific aggregation logic
   virtual void processAggregatedResponses(ClusterScopeCmdRequest& request) = 0;
 };
-
 
 /**
  * Handler for integer sum aggregation (PUBSUB NUMPAT, SLOWLOG LEN)
  */
 class IntegerSumAggregateResponseHandler : public BaseAggregateResponseHandler {
 public:
-  explicit IntegerSumAggregateResponseHandler(uint32_t shard_count) 
-    : BaseAggregateResponseHandler(shard_count) {}
+  explicit IntegerSumAggregateResponseHandler(uint32_t shard_count)
+      : BaseAggregateResponseHandler(shard_count) {}
 
 private:
   void processAggregatedResponses(ClusterScopeCmdRequest& request) override;
@@ -121,13 +120,12 @@ private:
  */
 class ArrayMergeAggregateResponseHandler : public BaseAggregateResponseHandler {
 public:
-  explicit ArrayMergeAggregateResponseHandler(uint32_t shard_count) 
-    : BaseAggregateResponseHandler(shard_count) {}
+  explicit ArrayMergeAggregateResponseHandler(uint32_t shard_count)
+      : BaseAggregateResponseHandler(shard_count) {}
 
 private:
   void processAggregatedResponses(ClusterScopeCmdRequest& request) override;
 };
-
 
 /**
  * Factory class for creating appropriate response handlers
@@ -141,8 +139,9 @@ public:
    * @param shard_count the number of shards for memory pre-allocation
    * @return unique pointer to the appropriate response handler
    */
-  static std::unique_ptr<BaseClusterScopeResponseHandler> 
-  createHandler(const std::string& command_name, const std::string& subcommand, uint32_t shard_count);
+  static std::unique_ptr<BaseClusterScopeResponseHandler>
+  createHandler(const std::string& command_name, const std::string& subcommand,
+                uint32_t shard_count);
 
   /**
    * Create a response handler from a Redis request
@@ -150,7 +149,7 @@ public:
    * @param shard_count the number of shards for memory pre-allocation
    * @return unique pointer to the appropriate response handler
    */
-  static std::unique_ptr<BaseClusterScopeResponseHandler> 
+  static std::unique_ptr<BaseClusterScopeResponseHandler>
   createFromRequest(const Common::Redis::RespValue& request, uint32_t shard_count);
 
 private:
@@ -161,8 +160,9 @@ private:
    * @param shard_count the number of shards for memory pre-allocation
    * @return unique pointer to the appropriate aggregate response handler
    */
-  static std::unique_ptr<BaseClusterScopeResponseHandler> 
-  createAggregateHandler(const std::string& command_name, const std::string& subcommand, uint32_t shard_count);
+  static std::unique_ptr<BaseClusterScopeResponseHandler>
+  createAggregateHandler(const std::string& command_name, const std::string& subcommand,
+                         uint32_t shard_count);
 
   /**
    * Get the response handler type for a given command and subcommand
@@ -170,8 +170,8 @@ private:
    * @param subcommand the Redis subcommand if applicable
    * @return the appropriate response handler type
    */
-  static ClusterScopeResponseHandlerType 
-  getResponseHandlerType(const std::string& command_name, const std::string& subcommand = "");
+  static ClusterScopeResponseHandlerType getResponseHandlerType(const std::string& command_name,
+                                                                const std::string& subcommand = "");
 };
 
 } // namespace CommandSplitter

--- a/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
+++ b/source/extensions/filters/network/redis_proxy/cluster_response_handler.h
@@ -43,6 +43,20 @@ public:
   void handleResponse(Common::Redis::RespValuePtr&& value, uint32_t shard_index,
                      ClusterScopeCmdRequest& request) final;
 
+  /**
+   * Handle a failure from a shard by converting it to an error response
+   * @param shard_index the shard that failed (same as request index)
+   * @param request the cluster scope request object (has all needed data)
+   */
+  void handleFailure(uint32_t shard_index, ClusterScopeCmdRequest& request) final;
+
+  /**
+   * Handle a failure from a shard
+   * @param shard_index the shard that failed (same as request index)
+   * @param request the cluster scope request object (has all needed data)
+   */
+  void handleFailure(uint32_t shard_index, ClusterScopeCmdRequest& request) final;
+
 protected:
   explicit BaseClusterScopeResponseHandler(uint32_t shard_count) {
     pending_responses_.reserve(shard_count);

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.cc
@@ -856,9 +856,9 @@ SplitRequestPtr ClusterScopeCmdRequest::create(Router& router,
     request_ptr->pending_requests_.emplace_back(*request_ptr, shard_index);
     PendingRequest& pending_request = request_ptr->pending_requests_.back();
 
-    // Send the same request to all shards
-    pending_request.handle_ = makeFragmentedRequest(
-        route, command, "", *base_request, pending_request, callbacks.transaction());
+    // Send the same request to all shards one by one
+    pending_request.handle_ = makeFragmentedRequestToShard(
+        route, command, shard_index, *base_request, pending_request, callbacks.transaction());
 
     if (!pending_request.handle_) {
       ENVOY_LOG(error, "{}:failed to create request handle for shard index {}: '{}'", __func__, shard_index, base_request->toString());

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -17,6 +17,7 @@
 #include "source/extensions/filters/network/redis_proxy/command_splitter.h"
 #include "source/extensions/filters/network/redis_proxy/conn_pool_impl.h"
 #include "source/extensions/filters/network/redis_proxy/router.h"
+#include "source/extensions/filters/network/redis_proxy/cluster_response_handler.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -326,6 +327,73 @@ private:
 };
 
 /**
+ * RandomShardRequest sends the command to a single random shard. This is used for commands like
+ * RANDOMKEY and CLUSTER that don't require responses from all shards, just one representative response.
+ * This optimizes performance by avoiding the overhead of sending to all shards.
+ */
+class RandomShardRequest : public FragmentedRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency,
+                                const StreamInfo::StreamInfo& stream_info);
+
+private:
+  RandomShardRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+
+  // RedisProxy::CommandSplitter::FragmentedRequest
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override;
+};
+
+/**
+ * ClusterScopeCmdRequest sends the command to all Redis servers, and the responses are handled specifically to its type.
+ * This class uses the strategy pattern with response handlers defined in cluster_response_handler.h
+ */
+class ClusterScopeCmdRequest : public FragmentedRequest {
+public:
+  static SplitRequestPtr create(Router& router, Common::Redis::RespValuePtr&& incoming_request,
+                                SplitCallbacks& callbacks, CommandStats& command_stats,
+                                TimeSource& time_source, bool delay_command_latency,
+                                const StreamInfo::StreamInfo& stream_info);
+
+private:
+  ClusterScopeCmdRequest(SplitCallbacks& callbacks, CommandStats& command_stats, TimeSource& time_source,
+              bool delay_command_latency)
+      : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}
+  
+  // Initialize response handler based on the incoming request
+  // Returns true on success, false on failure
+  bool initializeResponseHandler(const Common::Redis::RespValue& request, uint32_t shard_count) {
+    response_handler_ = ClusterResponseHandlerFactory::createFromRequest(request, shard_count);
+    if (!response_handler_) {
+      ENVOY_LOG(warn, "ClusterScopeCmdRequest: failed to initialize response handler for command: {}",
+                request.asArray().empty() ? "unknown" : request.asArray()[0].asString());
+      return false;
+    } else {
+      ENVOY_LOG(debug, "ClusterScopeCmdRequest: initialized response handler for command: {}",
+                request.asArray().empty() ? "unknown" : request.asArray()[0].asString());
+      return true;
+    }
+  }
+
+  // RedisProxy::CommandSplitter::FragmentedRequest
+  void onChildResponse(Common::Redis::RespValuePtr&& value, uint32_t index) override {
+    if (response_handler_) {
+      response_handler_->handleResponse(std::move(value), index, *this);
+    } else {
+      // No handler available for this command - send unsupported command error
+      ENVOY_LOG(warn, "No response handler set for ClusterScopeCmdRequest, command not supported");
+      updateStats(false);
+      callbacks_.onResponse(Common::Redis::Utility::makeError(Response::get().UpstreamFailure));
+    }
+  }
+
+  std::unique_ptr<BaseClusterScopeResponseHandler> response_handler_;
+};
+
+/**
  * InfoRequest sends the INFO command to all Redis servers and merges the results. The INFO command
  * provides information and statistics about the Redis server, and this request handles the
  * aggregation of that information from multiple servers.
@@ -499,8 +567,10 @@ private:
   CommandHandlerFactory<InfoRequest> info_handler_;
   CommandHandlerFactory<SelectRequest> select_handler_;
   CommandHandlerFactory<RoleRequest> role_handler_;
+  CommandHandlerFactory<RandomShardRequest> random_shard_handler_;
   CommandHandlerFactory<SplitKeysSumResultRequest> split_keys_sum_result_handler_;
   CommandHandlerFactory<TransactionRequest> transaction_handler_;
+  CommandHandlerFactory<ClusterScopeCmdRequest> cluster_scope_handler_;
   RadixTree<HandlerDataPtr> handler_lookup_table_;
   InstanceStats stats_;
   TimeSource& time_source_;

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -409,18 +409,6 @@ private:
     }
   }
 
-  void onChildFailure(uint32_t index) {
-    if (response_handler_) {
-      response_handler_->handleFailure(index, *this);
-    } else {
-      // No handler available for this command - fallback to base class behavior
-      ENVOY_LOG(
-          warn,
-          "No response handler set for ClusterScopeCmdRequest on failure, using base behavior");
-      FragmentedRequest::onChildFailure(index);
-    }
-  }
-
   std::unique_ptr<BaseClusterScopeResponseHandler> response_handler_;
 };
 

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -390,6 +390,16 @@ private:
     }
   }
 
+  void onChildFailure(uint32_t index) override {
+    if (response_handler_) {
+      response_handler_->handleFailure(index, *this);
+    } else {
+      // No handler available for this command - fallback to base class behavior
+      ENVOY_LOG(warn, "No response handler set for ClusterScopeCmdRequest on failure, using base behavior");
+      FragmentedRequest::onChildFailure(index);
+    }
+  }
+
   std::unique_ptr<BaseClusterScopeResponseHandler> response_handler_;
 };
 

--- a/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
+++ b/source/extensions/filters/network/redis_proxy/command_splitter_impl.h
@@ -375,6 +375,8 @@ public:
   size_t getTotalShardCount() const { return pending_requests_.size(); }
 
 private:
+  friend class ClusterScopeConfigTest;
+
   ClusterScopeCmdRequest(SplitCallbacks& callbacks, CommandStats& command_stats,
                          TimeSource& time_source, bool delay_command_latency)
       : FragmentedRequest(callbacks, command_stats, time_source, delay_command_latency) {}

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -2308,10 +2308,10 @@ TEST_F(ClusterScopeConfigTest, ConfigSetAllShardsReturnSame) {
   // All shards return OK
   pool_callbacks_[0]->onResponse(okResponse());
   pool_callbacks_[1]->onResponse(okResponse());
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(10));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 10));
+                          Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 10));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[2]->onResponse(okResponse());
 
@@ -2329,15 +2329,15 @@ TEST_F(ClusterScopeConfigTest, ConfigSetDifferentResponses) {
   expected_error.asString() = "all responses not same";
 
   pool_callbacks_[0]->onResponse(okResponse());
-  
+
   // Second shard returns different response
   auto different_response = std::make_unique<Common::Redis::RespValue>();
   different_response->type(Common::Redis::RespType::SimpleString);
   different_response->asString() = "DIFFERENT";
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(5));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 5));
+                          Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 5));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_error)));
   pool_callbacks_[1]->onResponse(std::move(different_response));
 
@@ -2351,10 +2351,10 @@ TEST_F(ClusterScopeConfigTest, ConfigSetOneShardError) {
   EXPECT_NE(nullptr, handle_);
 
   pool_callbacks_[0]->onResponse(okResponse());
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(8));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 8));
+                          Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 8));
   EXPECT_CALL(callbacks_, onResponse_(_)); // Should return the error
   pool_callbacks_[1]->onResponse(errorResponse("Configuration error"));
 
@@ -2368,10 +2368,10 @@ TEST_F(ClusterScopeConfigTest, ConfigSetShardFailure) {
   EXPECT_NE(nullptr, handle_);
 
   pool_callbacks_[0]->onResponse(okResponse());
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(12));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 12));
+                          Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 12));
   EXPECT_CALL(callbacks_, onResponse_(_)); // Should return failure error
   pool_callbacks_[1]->onFailure();
 
@@ -2398,7 +2398,7 @@ TEST_F(ClusterScopeConfigTest, ConfigSetNoUpstreamForSome) {
 
   time_system_.setMonotonicTime(std::chrono::milliseconds(6));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 6));
+                          Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 6));
   EXPECT_CALL(callbacks_, onResponse_(_));
   pool_callbacks_[1]->onResponse(okResponse());
 
@@ -2431,7 +2431,7 @@ TEST_F(ClusterScopeConfigTest, ConfigSetMirrored) {
 
   time_system_.setMonotonicTime(std::chrono::milliseconds(7));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 7));
+                          Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 7));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[1]->onResponse(okResponse());
   mirror_pool_callbacks_[1]->onResponse(okResponse());
@@ -2475,10 +2475,10 @@ TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenIntegerSum) {
 
   pool_callbacks_[0]->onResponse(integerResponse(50));
   pool_callbacks_[1]->onResponse(integerResponse(75));
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(15));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 15));
+                          Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 15));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[2]->onResponse(integerResponse(25));
 
@@ -2496,10 +2496,10 @@ TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenWithNegativeValues) {
   expected_error.asString() = "negative value received from upstream";
 
   pool_callbacks_[0]->onResponse(integerResponse(50));
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(6));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 6));
+                          Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 6));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_error)));
   pool_callbacks_[1]->onResponse(integerResponse(-10)); // Negative value should cause error
 
@@ -2513,10 +2513,10 @@ TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenNonIntegerResponse) {
   EXPECT_NE(nullptr, handle_);
 
   pool_callbacks_[0]->onResponse(integerResponse(50));
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(9));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 9));
+                          Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 9));
   EXPECT_CALL(callbacks_, onResponse_(_)); // Should get error response
   pool_callbacks_[1]->onResponse(stringResponse("not a number"));
 
@@ -2531,20 +2531,20 @@ TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenIntegerOverflow) {
 
   // Test with very large numbers close to int64_t max
   int64_t large_value = 9223372036854775800LL; // Close to INT64_MAX
-  
+
   Common::Redis::RespValue expected_response;
   expected_response.type(Common::Redis::RespType::Integer);
   expected_response.asInteger() = large_value + 5;
 
   pool_callbacks_[0]->onResponse(integerResponse(large_value));
-  
+
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[1]->onResponse(integerResponse(5));
 
   EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.success").value());
 }
 
-// Test cluster scope commands - SLOWLOG GET (ArrayMergeAggregateResponseHandler)  
+// Test cluster scope commands - SLOWLOG GET (ArrayMergeAggregateResponseHandler)
 class ClusterScopeSlowLogGetTest : public FragmentedRequestCommandHandlerTest {
 public:
   void setup(uint16_t shard_size, const std::list<uint64_t>& null_handle_indexes,
@@ -2594,10 +2594,10 @@ TEST_F(ClusterScopeSlowLogGetTest, SlowLogGetArrayMerge) {
   expected_response.asArray().swap(elements);
 
   pool_callbacks_[0]->onResponse(arrayResponse({"entry1", "entry2"}));
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(20));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 20));
+                          Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 20));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[1]->onResponse(arrayResponse({"entry3", "entry4"}));
 
@@ -2615,7 +2615,7 @@ TEST_F(ClusterScopeSlowLogGetTest, SlowLogGetEmptyArrays) {
   // Empty array expected
 
   pool_callbacks_[0]->onResponse(arrayResponse({}));
-  
+
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
   pool_callbacks_[1]->onResponse(arrayResponse({}));
 
@@ -2628,11 +2628,11 @@ TEST_F(ClusterScopeSlowLogGetTest, SlowLogGetNonArrayResponse) {
   EXPECT_NE(nullptr, handle_);
 
   pool_callbacks_[0]->onResponse(arrayResponse({"entry1"}));
-  
+
   time_system_.setMonotonicTime(std::chrono::milliseconds(13));
   EXPECT_CALL(store_, deliverHistogramToSinks(
-      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 13));
-  EXPECT_CALL(callbacks_, onResponse_(_)); // Should get error response
+                          Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 13));
+  EXPECT_CALL(callbacks_, onResponse_(_));              // Should get error response
   pool_callbacks_[1]->onResponse(integerResponse(123)); // Non-array response
 
   EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
@@ -2644,7 +2644,7 @@ TEST_F(RedisCommandSplitterImplTest, UnsupportedClusterScopeCommand) {
   Common::Redis::RespValue response;
   response.type(Common::Redis::RespType::Error);
   response.asString() = "ERR cluster subcommand 'reset' is not supported";
-  
+
   EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
@@ -2660,7 +2660,7 @@ TEST_F(RedisCommandSplitterImplTest, ClusterScopeCommandInvalidArgs) {
   Common::Redis::RespValue response;
   response.type(Common::Redis::RespType::Error);
   response.asString() = Response::get().InvalidRequest;
-  
+
   EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
   Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
@@ -2674,24 +2674,24 @@ TEST_F(RedisCommandSplitterImplTest, ClusterScopeCommandInvalidArgs) {
 // Test ClusterResponseHandlerFactory integration
 class ClusterResponseHandlerFactoryTest : public testing::Test {
 public:
-  std::unique_ptr<Common::Redis::RespValue> makeRequest(const std::string& command, 
-                                                       const std::string& subcommand = "") {
+  std::unique_ptr<Common::Redis::RespValue> makeRequest(const std::string& command,
+                                                        const std::string& subcommand = "") {
     auto request = std::make_unique<Common::Redis::RespValue>();
     request->type(Common::Redis::RespType::Array);
     std::vector<Common::Redis::RespValue> elements;
-    
+
     Common::Redis::RespValue cmd;
     cmd.type(Common::Redis::RespType::BulkString);
     cmd.asString() = command;
     elements.push_back(std::move(cmd));
-    
+
     if (!subcommand.empty()) {
       Common::Redis::RespValue subcmd;
       subcmd.type(Common::Redis::RespType::BulkString);
       subcmd.asString() = subcommand;
       elements.push_back(std::move(subcmd));
     }
-    
+
     request->asArray().swap(elements);
     return request;
   }
@@ -2700,23 +2700,16 @@ public:
 TEST_F(ClusterResponseHandlerFactoryTest, CreateAllshardSameHandlers) {
   // Test all commands that should use AllshardSameResponseHandler
   std::vector<std::pair<std::string, std::string>> same_response_commands = {
-    {"config", "set"},
-    {"config", "rewrite"},
-    {"config", "resetstat"},
-    {"flushall", ""},
-    {"flushdb", ""},
-    {"script", "flush"},
-    {"script", "kill"},
-    {"slowlog", "reset"}
-  };
+      {"config", "set"}, {"config", "rewrite"}, {"config", "resetstat"}, {"flushall", ""},
+      {"flushdb", ""},   {"script", "flush"},   {"script", "kill"},      {"slowlog", "reset"}};
 
   for (const auto& cmd_pair : same_response_commands) {
     auto handler = ClusterResponseHandlerFactory::createFromRequest(
         *makeRequest(cmd_pair.first, cmd_pair.second), 3);
-    
-    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first 
-                               << (cmd_pair.second.empty() ? "" : " " + cmd_pair.second);
-    
+
+    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first
+                                << (cmd_pair.second.empty() ? "" : " " + cmd_pair.second);
+
     // Verify it's the correct type by testing behavior
     // AllshardSameResponseHandler should be created
   }
@@ -2724,32 +2717,28 @@ TEST_F(ClusterResponseHandlerFactoryTest, CreateAllshardSameHandlers) {
 
 TEST_F(ClusterResponseHandlerFactoryTest, CreateIntegerSumHandlers) {
   // Test commands that should use IntegerSumAggregateResponseHandler
-  std::vector<std::pair<std::string, std::string>> integer_sum_commands = {
-    {"slowlog", "len"}
-  };
+  std::vector<std::pair<std::string, std::string>> integer_sum_commands = {{"slowlog", "len"}};
 
   for (const auto& cmd_pair : integer_sum_commands) {
     auto handler = ClusterResponseHandlerFactory::createFromRequest(
         *makeRequest(cmd_pair.first, cmd_pair.second), 3);
-    
-    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first 
-                               << " " << cmd_pair.second;
+
+    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first << " "
+                                << cmd_pair.second;
   }
 }
 
 TEST_F(ClusterResponseHandlerFactoryTest, CreateArrayMergeHandlers) {
   // Test commands that should use ArrayMergeAggregateResponseHandler
-  std::vector<std::pair<std::string, std::string>> array_merge_commands = {
-    {"slowlog", "get"},
-    {"config", "get"}
-  };
+  std::vector<std::pair<std::string, std::string>> array_merge_commands = {{"slowlog", "get"},
+                                                                           {"config", "get"}};
 
   for (const auto& cmd_pair : array_merge_commands) {
     auto handler = ClusterResponseHandlerFactory::createFromRequest(
         *makeRequest(cmd_pair.first, cmd_pair.second), 3);
-    
-    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first 
-                               << " " << cmd_pair.second;
+
+    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first << " "
+                                << cmd_pair.second;
   }
 }
 
@@ -2757,7 +2746,7 @@ TEST_F(ClusterResponseHandlerFactoryTest, CreateArrayMergeHandlers) {
 class ClusterScopeCommandRoutingTest : public RedisCommandSplitterImplTest {
 public:
   void testCommandRouting(const std::string& command, const std::string& subcommand,
-                         bool should_create_handler) {
+                          bool should_create_handler) {
     Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
     std::vector<std::string> cmd_args = {command};
     if (!subcommand.empty()) {
@@ -2769,7 +2758,7 @@ public:
       // For supported cluster scope commands, we expect the request to be handled
       EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
       EXPECT_CALL(*conn_pool_, shardSize_()).WillOnce(Return(2));
-      
+
       ConnPool::PoolCallbacks* pool_callback1;
       ConnPool::PoolCallbacks* pool_callback2;
       Common::Redis::Client::MockPoolRequest pool_request1;
@@ -2781,10 +2770,11 @@ public:
       EXPECT_CALL(*conn_pool_, makeRequestToShard_(1, _, _))
           .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callback2)), Return(&pool_request2)));
 
-      auto handle = splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
-      EXPECT_NE(nullptr, handle) << "Should create handle for " << command 
-                                << (subcommand.empty() ? "" : " " + subcommand);
-      
+      auto handle =
+          splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+      EXPECT_NE(nullptr, handle) << "Should create handle for " << command
+                                 << (subcommand.empty() ? "" : " " + subcommand);
+
       // Clean up the handle by simulating completion
       if (handle) {
         auto response1 = std::make_unique<Common::Redis::RespValue>();
@@ -2793,7 +2783,7 @@ public:
         auto response2 = std::make_unique<Common::Redis::RespValue>();
         response2->type(Common::Redis::RespType::SimpleString);
         response2->asString() = "OK";
-        
+
         EXPECT_CALL(callbacks_, onResponse_(_));
         pool_callback1->onResponse(std::move(response1));
         pool_callback2->onResponse(std::move(response2));
@@ -2802,22 +2792,21 @@ public:
       // For unsupported commands, we expect an error response
       EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
       EXPECT_CALL(callbacks_, onResponse_(_));
-      auto handle = splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
-      EXPECT_EQ(nullptr, handle) << "Should NOT create handle for " << command 
-                                << (subcommand.empty() ? "" : " " + subcommand);
+      auto handle =
+          splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+      EXPECT_EQ(nullptr, handle) << "Should NOT create handle for " << command
+                                 << (subcommand.empty() ? "" : " " + subcommand);
     }
   }
 };
 
 TEST_F(ClusterScopeCommandRoutingTest, SupportedClusterScopeCommands) {
   // Test that all supported cluster scope commands are properly routed
-  std::vector<std::pair<std::string, std::string>> supported_commands = {
-    {"config", "set"},
-    {"config", "get"},
-    {"flushall", ""},
-    {"slowlog", "len"},
-    {"slowlog", "get"}
-  };
+  std::vector<std::pair<std::string, std::string>> supported_commands = {{"config", "set"},
+                                                                         {"config", "get"},
+                                                                         {"flushall", ""},
+                                                                         {"slowlog", "len"},
+                                                                         {"slowlog", "get"}};
 
   for (const auto& cmd_pair : supported_commands) {
     testCommandRouting(cmd_pair.first, cmd_pair.second, true);
@@ -2827,18 +2816,18 @@ TEST_F(ClusterScopeCommandRoutingTest, SupportedClusterScopeCommands) {
 TEST_F(ClusterScopeCommandRoutingTest, NoShardsAvailable) {
   // Test that cluster scope commands fail gracefully when no shards are available
   InSequence s;
-  
+
   Common::Redis::RespValue expected_response;
   expected_response.type(Common::Redis::RespType::Error);
   expected_response.asString() = "no upstream host";
-  
+
   Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
   makeBulkStringArray(*request, {"config", "set", "maxmemory", "100mb"});
-  
+
   EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
   EXPECT_CALL(*conn_pool_, shardSize_()).WillOnce(Return(0));
   EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
-  
+
   auto handle = splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
   EXPECT_EQ(nullptr, handle);
 }

--- a/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
+++ b/test/extensions/filters/network/redis_proxy/command_splitter_impl_test.cc
@@ -2265,6 +2265,1010 @@ TEST_F(RoleHandlerTest, RoleNoArgs) {
 }
 
 INSTANTIATE_TEST_SUITE_P(RoleHandlerTest, RoleHandlerTest, testing::Values("role"));
+
+// ===== CLUSTER SCOPE COMMAND TESTS =====
+
+// Test cluster scope commands - CONFIG SET (AllshardSameResponseHandler)
+class ClusterScopeConfigTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void setup(uint16_t shard_size, const std::list<uint64_t>& null_handle_indexes,
+             bool mirrored = false) {
+    std::vector<std::string> request_strings = {"config", "set", "maxmemory", "100mb"};
+    makeRequestToShard(shard_size, request_strings, null_handle_indexes, mirrored);
+  }
+
+  Common::Redis::RespValuePtr okResponse() {
+    auto response = std::make_unique<Common::Redis::RespValue>();
+    response->type(Common::Redis::RespType::SimpleString);
+    response->asString() = "OK";
+    return response;
+  }
+
+  Common::Redis::RespValuePtr errorResponse(const std::string& error_msg) {
+    return Common::Redis::Utility::makeError(error_msg);
+  }
+};
+
+TEST_F(ClusterScopeConfigTest, ConfigSetAllShardsReturnSame) {
+  InSequence s;
+  setup(3, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::SimpleString);
+  expected_response.asString() = "OK";
+
+  // All shards return OK
+  pool_callbacks_[0]->onResponse(okResponse());
+  pool_callbacks_[1]->onResponse(okResponse());
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(10));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 10));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[2]->onResponse(okResponse());
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.success").value());
+}
+
+TEST_F(ClusterScopeConfigTest, ConfigSetDifferentResponses) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_error;
+  expected_error.type(Common::Redis::RespType::Error);
+  expected_error.asString() = "all responses not same";
+
+  pool_callbacks_[0]->onResponse(okResponse());
+  
+  // Second shard returns different response
+  auto different_response = std::make_unique<Common::Redis::RespValue>();
+  different_response->type(Common::Redis::RespType::SimpleString);
+  different_response->asString() = "DIFFERENT";
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(5));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 5));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_error)));
+  pool_callbacks_[1]->onResponse(std::move(different_response));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.error").value());
+}
+
+TEST_F(ClusterScopeConfigTest, ConfigSetOneShardError) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  pool_callbacks_[0]->onResponse(okResponse());
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(8));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 8));
+  EXPECT_CALL(callbacks_, onResponse_(_)); // Should return the error
+  pool_callbacks_[1]->onResponse(errorResponse("Configuration error"));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.error").value());
+}
+
+TEST_F(ClusterScopeConfigTest, ConfigSetShardFailure) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  pool_callbacks_[0]->onResponse(okResponse());
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(12));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 12));
+  EXPECT_CALL(callbacks_, onResponse_(_)); // Should return failure error
+  pool_callbacks_[1]->onFailure();
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.error").value());
+}
+
+TEST_F(ClusterScopeConfigTest, ConfigSetNoUpstreamForAll) {
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Error);
+  expected_response.asString() = "no upstream host";
+
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  setup(0, {});
+  EXPECT_EQ(nullptr, handle_);
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.error").value());
+}
+
+TEST_F(ClusterScopeConfigTest, ConfigSetNoUpstreamForSome) {
+  InSequence s;
+  setup(2, {0});
+  EXPECT_NE(nullptr, handle_);
+
+  time_system_.setMonotonicTime(std::chrono::milliseconds(6));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 6));
+  EXPECT_CALL(callbacks_, onResponse_(_));
+  pool_callbacks_[1]->onResponse(okResponse());
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.error").value());
+}
+
+TEST_F(ClusterScopeConfigTest, ConfigSetCancel) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  EXPECT_CALL(pool_requests_[0], cancel());
+  EXPECT_CALL(pool_requests_[1], cancel());
+  handle_->cancel();
+}
+
+TEST_F(ClusterScopeConfigTest, ConfigSetMirrored) {
+  InSequence s;
+  setupMirrorPolicy();
+  setup(2, {}, true);
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::SimpleString);
+  expected_response.asString() = "OK";
+
+  pool_callbacks_[0]->onResponse(okResponse());
+  mirror_pool_callbacks_[0]->onResponse(okResponse());
+
+  time_system_.setMonotonicTime(std::chrono::milliseconds(7));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 7));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[1]->onResponse(okResponse());
+  mirror_pool_callbacks_[1]->onResponse(okResponse());
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.success").value());
+}
+
+// Test cluster scope commands - SLOWLOG LEN (IntegerSumAggregateResponseHandler)
+class ClusterScopeSlowLogLenTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void setup(uint16_t shard_size, const std::list<uint64_t>& null_handle_indexes,
+             bool mirrored = false) {
+    std::vector<std::string> request_strings = {"slowlog", "len"};
+    makeRequestToShard(shard_size, request_strings, null_handle_indexes, mirrored);
+  }
+
+  Common::Redis::RespValuePtr integerResponse(int64_t value) {
+    auto response = std::make_unique<Common::Redis::RespValue>();
+    response->type(Common::Redis::RespType::Integer);
+    response->asInteger() = value;
+    return response;
+  }
+
+  Common::Redis::RespValuePtr stringResponse(const std::string& value) {
+    auto response = std::make_unique<Common::Redis::RespValue>();
+    response->type(Common::Redis::RespType::BulkString);
+    response->asString() = value;
+    return response;
+  }
+};
+
+TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenIntegerSum) {
+  InSequence s;
+  setup(3, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Integer);
+  expected_response.asInteger() = 150; // 50 + 75 + 25
+
+  pool_callbacks_[0]->onResponse(integerResponse(50));
+  pool_callbacks_[1]->onResponse(integerResponse(75));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(15));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 15));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[2]->onResponse(integerResponse(25));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.success").value());
+}
+
+TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenWithNegativeValues) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_error;
+  expected_error.type(Common::Redis::RespType::Error);
+  expected_error.asString() = "negative value received from upstream";
+
+  pool_callbacks_[0]->onResponse(integerResponse(50));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(6));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 6));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_error)));
+  pool_callbacks_[1]->onResponse(integerResponse(-10)); // Negative value should cause error
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.error").value());
+}
+
+TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenNonIntegerResponse) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  pool_callbacks_[0]->onResponse(integerResponse(50));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(9));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 9));
+  EXPECT_CALL(callbacks_, onResponse_(_)); // Should get error response
+  pool_callbacks_[1]->onResponse(stringResponse("not a number"));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.error").value());
+}
+
+TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenShardFailure) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  pool_callbacks_[0]->onResponse(integerResponse(100));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(11));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 11));
+  EXPECT_CALL(callbacks_, onResponse_(_)); // Should get error response
+  pool_callbacks_[1]->onFailure();
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.error").value());
+}
+
+TEST_F(ClusterScopeSlowLogLenTest, SlowLogLenIntegerOverflow) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  // Test with very large numbers close to int64_t max
+  int64_t large_value = 9223372036854775800LL; // Close to INT64_MAX
+  
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Integer);
+  expected_response.asInteger() = large_value + 5;
+
+  pool_callbacks_[0]->onResponse(integerResponse(large_value));
+  
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[1]->onResponse(integerResponse(5));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.success").value());
+}
+
+// Test cluster scope commands - SLOWLOG GET (ArrayMergeAggregateResponseHandler)  
+class ClusterScopeSlowLogGetTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void setup(uint16_t shard_size, const std::list<uint64_t>& null_handle_indexes,
+             bool mirrored = false) {
+    std::vector<std::string> request_strings = {"slowlog", "get", "5"};
+    makeRequestToShard(shard_size, request_strings, null_handle_indexes, mirrored);
+  }
+
+  Common::Redis::RespValuePtr arrayResponse(const std::vector<std::string>& values) {
+    auto response = std::make_unique<Common::Redis::RespValue>();
+    response->type(Common::Redis::RespType::Array);
+    std::vector<Common::Redis::RespValue> elements;
+    for (const auto& val : values) {
+      Common::Redis::RespValue elem;
+      elem.type(Common::Redis::RespType::BulkString);
+      elem.asString() = val;
+      elements.push_back(std::move(elem));
+    }
+    response->asArray().swap(elements);
+    return response;
+  }
+
+  Common::Redis::RespValuePtr integerResponse(int64_t value) {
+    auto response = std::make_unique<Common::Redis::RespValue>();
+    response->type(Common::Redis::RespType::Integer);
+    response->asInteger() = value;
+    return response;
+  }
+};
+
+TEST_F(ClusterScopeSlowLogGetTest, SlowLogGetArrayMerge) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(4);
+  elements[0].type(Common::Redis::RespType::BulkString);
+  elements[0].asString() = "entry1";
+  elements[1].type(Common::Redis::RespType::BulkString);
+  elements[1].asString() = "entry2";
+  elements[2].type(Common::Redis::RespType::BulkString);
+  elements[2].asString() = "entry3";
+  elements[3].type(Common::Redis::RespType::BulkString);
+  elements[3].asString() = "entry4";
+  expected_response.asArray().swap(elements);
+
+  pool_callbacks_[0]->onResponse(arrayResponse({"entry1", "entry2"}));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(20));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 20));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[1]->onResponse(arrayResponse({"entry3", "entry4"}));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.success").value());
+}
+
+TEST_F(ClusterScopeSlowLogGetTest, SlowLogGetEmptyArrays) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  // Empty array expected
+
+  pool_callbacks_[0]->onResponse(arrayResponse({}));
+  
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[1]->onResponse(arrayResponse({}));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.success").value());
+}
+
+TEST_F(ClusterScopeSlowLogGetTest, SlowLogGetNonArrayResponse) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  pool_callbacks_[0]->onResponse(arrayResponse({"entry1"}));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(13));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 13));
+  EXPECT_CALL(callbacks_, onResponse_(_)); // Should get error response
+  pool_callbacks_[1]->onResponse(integerResponse(123)); // Non-array response
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.error").value());
+}
+
+TEST_F(ClusterScopeSlowLogGetTest, SlowLogGetShardFailure) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  pool_callbacks_[0]->onResponse(arrayResponse({"entry1", "entry2"}));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(14));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.slowlog.latency"), 14));
+  EXPECT_CALL(callbacks_, onResponse_(_)); // Should get error response
+  pool_callbacks_[1]->onFailure();
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.slowlog.error").value());
+}
+
+// Test FLUSHALL command (AllshardSameResponseHandler)
+class ClusterScopeFlushAllTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void setup(uint16_t shard_size, const std::list<uint64_t>& null_handle_indexes,
+             bool mirrored = false) {
+    std::vector<std::string> request_strings = {"flushall"};
+    makeRequestToShard(shard_size, request_strings, null_handle_indexes, mirrored);
+  }
+
+  Common::Redis::RespValuePtr okResponse() {
+    auto response = std::make_unique<Common::Redis::RespValue>();
+    response->type(Common::Redis::RespType::SimpleString);
+    response->asString() = "OK";
+    return response;
+  }
+};
+
+TEST_F(ClusterScopeFlushAllTest, FlushAllSuccess) {
+  InSequence s;
+  setup(3, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::SimpleString);
+  expected_response.asString() = "OK";
+
+  pool_callbacks_[0]->onResponse(okResponse());
+  pool_callbacks_[1]->onResponse(okResponse());
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(25));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.flushall.latency"), 25));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[2]->onResponse(okResponse());
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.flushall.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.flushall.success").value());
+}
+
+// Test CONFIG GET command (ArrayMergeAggregateResponseHandler)
+class ClusterScopeConfigGetTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void setup(uint16_t shard_size, const std::list<uint64_t>& null_handle_indexes,
+             bool mirrored = false) {
+    std::vector<std::string> request_strings = {"config", "get", "max*"};
+    makeRequestToShard(shard_size, request_strings, null_handle_indexes, mirrored);
+  }
+
+  Common::Redis::RespValuePtr arrayResponse(const std::vector<std::string>& values) {
+    auto response = std::make_unique<Common::Redis::RespValue>();
+    response->type(Common::Redis::RespType::Array);
+    std::vector<Common::Redis::RespValue> elements;
+    for (const auto& val : values) {
+      Common::Redis::RespValue elem;
+      elem.type(Common::Redis::RespType::BulkString);
+      elem.asString() = val;
+      elements.push_back(std::move(elem));
+    }
+    response->asArray().swap(elements);
+    return response;
+  }
+};
+
+TEST_F(ClusterScopeConfigGetTest, ConfigGetArrayMerge) {
+  InSequence s;
+  setup(2, {});
+  EXPECT_NE(nullptr, handle_);
+
+  Common::Redis::RespValue expected_response;
+  expected_response.type(Common::Redis::RespType::Array);
+  std::vector<Common::Redis::RespValue> elements(4);
+  elements[0].type(Common::Redis::RespType::BulkString);
+  elements[0].asString() = "maxmemory";
+  elements[1].type(Common::Redis::RespType::BulkString);
+  elements[1].asString() = "100mb";
+  elements[2].type(Common::Redis::RespType::BulkString);
+  elements[2].asString() = "maxclients";
+  elements[3].type(Common::Redis::RespType::BulkString);
+  elements[3].asString() = "1000";
+  expected_response.asArray().swap(elements);
+
+  pool_callbacks_[0]->onResponse(arrayResponse({"maxmemory", "100mb"}));
+  
+  time_system_.setMonotonicTime(std::chrono::milliseconds(18));
+  EXPECT_CALL(store_, deliverHistogramToSinks(
+      Property(&Stats::Metric::name, "redis.foo.command.config.latency"), 18));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&expected_response)));
+  pool_callbacks_[1]->onResponse(arrayResponse({"maxclients", "1000"}));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.total").value());
+  EXPECT_EQ(1UL, store_.counter("redis.foo.command.config.success").value());
+}
+
+// Test unsupported cluster scope command
+TEST_F(RedisCommandSplitterImplTest, UnsupportedClusterScopeCommand) {
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
+  response.asString() = "ERR unknown command 'cluster', with args beginning with: reset";
+  
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"cluster", "reset"});
+  EXPECT_EQ(nullptr,
+            splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_));
+
+  EXPECT_EQ(1UL, store_.counter("redis.foo.splitter.unsupported_command").value());
+}
+
+// Test edge cases
+TEST_F(RedisCommandSplitterImplTest, ClusterScopeCommandInvalidArgs) {
+  Common::Redis::RespValue response;
+  response.type(Common::Redis::RespType::Error);
+  response.asString() = "wrong number of arguments for 'config' command";
+  
+  EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
+  EXPECT_CALL(callbacks_, onResponse_(PointeesEq(&response)));
+  Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+  makeBulkStringArray(*request, {"config"}); // Missing subcommand
+  EXPECT_EQ(nullptr,
+            splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_));
+}
+
+// ===== FRAMEWORK INTEGRATION AND INTEGRITY TESTS =====
+
+// Test ClusterResponseHandlerFactory integration
+class ClusterResponseHandlerFactoryTest : public testing::Test {
+public:
+  std::unique_ptr<Common::Redis::RespValue> makeRequest(const std::string& command, 
+                                                       const std::string& subcommand = "") {
+    auto request = std::make_unique<Common::Redis::RespValue>();
+    request->type(Common::Redis::RespType::Array);
+    std::vector<Common::Redis::RespValue> elements;
+    
+    Common::Redis::RespValue cmd;
+    cmd.type(Common::Redis::RespType::BulkString);
+    cmd.asString() = command;
+    elements.push_back(std::move(cmd));
+    
+    if (!subcommand.empty()) {
+      Common::Redis::RespValue subcmd;
+      subcmd.type(Common::Redis::RespType::BulkString);
+      subcmd.asString() = subcommand;
+      elements.push_back(std::move(subcmd));
+    }
+    
+    request->asArray().swap(elements);
+    return request;
+  }
+};
+
+TEST_F(ClusterResponseHandlerFactoryTest, CreateAllshardSameHandlers) {
+  // Test all commands that should use AllshardSameResponseHandler
+  std::vector<std::pair<std::string, std::string>> same_response_commands = {
+    {"config", "set"},
+    {"config", "rewrite"},
+    {"config", "resetstat"},
+    {"flushall", ""},
+    {"flushdb", ""},
+    {"script", "flush"},
+    {"script", "kill"},
+    {"slowlog", "reset"},
+    {"unwatch", ""}
+  };
+
+  for (const auto& cmd_pair : same_response_commands) {
+    auto handler = ClusterResponseHandlerFactory::createFromRequest(
+        *makeRequest(cmd_pair.first, cmd_pair.second), 3);
+    
+    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first 
+                               << (cmd_pair.second.empty() ? "" : " " + cmd_pair.second);
+    
+    // Verify it's the correct type by testing behavior
+    // AllshardSameResponseHandler should be created
+  }
+}
+
+TEST_F(ClusterResponseHandlerFactoryTest, CreateIntegerSumHandlers) {
+  // Test commands that should use IntegerSumAggregateResponseHandler
+  std::vector<std::pair<std::string, std::string>> integer_sum_commands = {
+    {"slowlog", "len"}
+  };
+
+  for (const auto& cmd_pair : integer_sum_commands) {
+    auto handler = ClusterResponseHandlerFactory::createFromRequest(
+        *makeRequest(cmd_pair.first, cmd_pair.second), 3);
+    
+    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first 
+                               << " " << cmd_pair.second;
+  }
+}
+
+TEST_F(ClusterResponseHandlerFactoryTest, CreateArrayMergeHandlers) {
+  // Test commands that should use ArrayMergeAggregateResponseHandler
+  std::vector<std::pair<std::string, std::string>> array_merge_commands = {
+    {"slowlog", "get"},
+    {"config", "get"}
+  };
+
+  for (const auto& cmd_pair : array_merge_commands) {
+    auto handler = ClusterResponseHandlerFactory::createFromRequest(
+        *makeRequest(cmd_pair.first, cmd_pair.second), 3);
+    
+    EXPECT_NE(nullptr, handler) << "Handler should be created for " << cmd_pair.first 
+                               << " " << cmd_pair.second;
+  }
+}
+
+TEST_F(ClusterResponseHandlerFactoryTest, UnsupportedCommands) {
+  // Test that unsupported commands return nullptr
+  std::vector<std::pair<std::string, std::string>> unsupported_commands = {
+    {"unsupported", ""},
+    {"get", ""},           // Not a cluster scope command
+    {"set", ""},           // Not a cluster scope command
+    {"config", "unknown"}, // Invalid subcommand
+    {"slowlog", "unknown"} // Invalid subcommand
+  };
+
+  for (const auto& cmd_pair : unsupported_commands) {
+    auto handler = ClusterResponseHandlerFactory::createFromRequest(
+        *makeRequest(cmd_pair.first, cmd_pair.second), 3);
+    
+    EXPECT_EQ(nullptr, handler) << "Handler should NOT be created for " << cmd_pair.first 
+                               << (cmd_pair.second.empty() ? "" : " " + cmd_pair.second);
+  }
+}
+
+TEST_F(ClusterResponseHandlerFactoryTest, InvalidRequests) {
+  // Test invalid request formats
+  auto empty_request = std::make_unique<Common::Redis::RespValue>();
+  empty_request->type(Common::Redis::RespType::Array);
+  
+  auto handler = ClusterResponseHandlerFactory::createFromRequest(*empty_request, 3);
+  EXPECT_EQ(nullptr, handler);
+
+  // Test non-array request
+  auto string_request = std::make_unique<Common::Redis::RespValue>();
+  string_request->type(Common::Redis::RespType::BulkString);
+  string_request->asString() = "config";
+  
+  handler = ClusterResponseHandlerFactory::createFromRequest(*string_request, 3);
+  EXPECT_EQ(nullptr, handler);
+}
+
+TEST_F(ClusterResponseHandlerFactoryTest, MemoryAllocationOptimization) {
+  // Test that handlers are created with proper shard count for memory optimization
+  for (uint32_t shard_count : {1, 5, 10, 100}) {
+    auto handler = ClusterResponseHandlerFactory::createFromRequest(
+        *makeRequest("config", "set"), shard_count);
+    
+    EXPECT_NE(nullptr, handler) << "Handler should be created for shard count " << shard_count;
+    // The handler should have reserved memory for shard_count responses
+  }
+}
+
+// Test command routing integration
+class ClusterScopeCommandRoutingTest : public RedisCommandSplitterImplTest {
+public:
+  void testCommandRouting(const std::string& command, const std::string& subcommand,
+                         bool should_create_handler) {
+    Common::Redis::RespValuePtr request{new Common::Redis::RespValue()};
+    std::vector<std::string> cmd_args = {command};
+    if (!subcommand.empty()) {
+      cmd_args.push_back(subcommand);
+    }
+    makeBulkStringArray(*request, cmd_args);
+
+    if (should_create_handler) {
+      // For supported cluster scope commands, we expect the request to be handled
+      EXPECT_CALL(callbacks_, connectionAllowed()).WillOnce(Return(true));
+      EXPECT_CALL(*conn_pool_, shardSize_()).WillOnce(Return(2));
+      
+      ConnPool::PoolCallbacks* pool_callback1;
+      ConnPool::PoolCallbacks* pool_callback2;
+      Common::Redis::Client::MockPoolRequest pool_request1;
+      Common::Redis::Client::MockPoolRequest pool_request2;
+
+      ConnPool::RespVariant keys(*request);
+      EXPECT_CALL(*conn_pool_, makeRequestToShard_(0, keys, _))
+          .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callback1)), Return(&pool_request1)));
+      EXPECT_CALL(*conn_pool_, makeRequestToShard_(1, keys, _))
+          .WillOnce(DoAll(WithArg<2>(SaveArgAddress(&pool_callback2)), Return(&pool_request2)));
+
+      auto handle = splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+      EXPECT_NE(nullptr, handle) << "Should create handle for " << command 
+                                << (subcommand.empty() ? "" : " " + subcommand);
+    } else {
+      // For unsupported commands, we expect an error response
+      EXPECT_CALL(callbacks_, onResponse_(_));
+      auto handle = splitter_.makeRequest(std::move(request), callbacks_, dispatcher_, stream_info_);
+      EXPECT_EQ(nullptr, handle) << "Should NOT create handle for " << command 
+                                << (subcommand.empty() ? "" : " " + subcommand);
+    }
+  }
+};
+
+TEST_F(ClusterScopeCommandRoutingTest, SupportedClusterScopeCommands) {
+  // Test that all supported cluster scope commands are properly routed
+  std::vector<std::pair<std::string, std::string>> supported_commands = {
+    {"config", "set"},
+    {"config", "get"},
+    {"flushall", ""},
+    {"slowlog", "len"},
+    {"slowlog", "get"}
+  };
+
+  for (const auto& cmd_pair : supported_commands) {
+    testCommandRouting(cmd_pair.first, cmd_pair.second, true);
+  }
+}
+
+TEST_F(ClusterScopeCommandRoutingTest, UnsupportedCommands) {
+  // Test that unsupported commands are properly rejected
+  std::vector<std::pair<std::string, std::string>> unsupported_commands = {
+    {"get", ""},
+    {"set", ""},
+    {"unknown", ""},
+    {"config", "unknown"}
+  };
+
+  for (const auto& cmd_pair : unsupported_commands) {
+    testCommandRouting(cmd_pair.first, cmd_pair.second, false);
+  }
+}
+
+// Test framework consistency across all handler types
+class ClusterScopeFrameworkConsistencyTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void testHandlerConsistency(const std::string& command, const std::string& subcommand,
+                             uint16_t shard_count) {
+    std::vector<std::string> request_strings = {command};
+    if (!subcommand.empty()) {
+      request_strings.push_back(subcommand);
+    }
+    makeRequestToShard(shard_count, request_strings, {}, false);
+    EXPECT_NE(nullptr, handle_) << "Handler should be created for " << command;
+
+    // Test that all handlers properly track stats
+    std::string stat_prefix = "redis.foo.command." + command;
+    
+    // Create appropriate responses for each handler type
+    if ((command == "config" && subcommand == "set") || 
+        command == "flushall" || command == "flushdb") {
+      // AllshardSameResponseHandler - send same response to all
+      auto ok_response = std::make_unique<Common::Redis::RespValue>();
+      ok_response->type(Common::Redis::RespType::SimpleString);
+      ok_response->asString() = "OK";
+      
+      for (uint16_t i = 0; i < shard_count - 1; i++) {
+        auto response_copy = std::make_unique<Common::Redis::RespValue>();
+        response_copy->type(Common::Redis::RespType::SimpleString);
+        response_copy->asString() = "OK";
+        pool_callbacks_[i]->onResponse(std::move(response_copy));
+      }
+      
+      time_system_.setMonotonicTime(std::chrono::milliseconds(5));
+      EXPECT_CALL(store_, deliverHistogramToSinks(
+          Property(&Stats::Metric::name, stat_prefix + ".latency"), 5));
+      EXPECT_CALL(callbacks_, onResponse_(_));
+      pool_callbacks_[shard_count - 1]->onResponse(std::move(ok_response));
+      
+    } else if (command == "slowlog" && subcommand == "len") {
+      // IntegerSumAggregateResponseHandler
+      for (uint16_t i = 0; i < shard_count - 1; i++) {
+        auto int_response = std::make_unique<Common::Redis::RespValue>();
+        int_response->type(Common::Redis::RespType::Integer);
+        int_response->asInteger() = 10;
+        pool_callbacks_[i]->onResponse(std::move(int_response));
+      }
+      
+      auto final_response = std::make_unique<Common::Redis::RespValue>();
+      final_response->type(Common::Redis::RespType::Integer);
+      final_response->asInteger() = 10;
+      
+      time_system_.setMonotonicTime(std::chrono::milliseconds(8));
+      EXPECT_CALL(store_, deliverHistogramToSinks(
+          Property(&Stats::Metric::name, stat_prefix + ".latency"), 8));
+      EXPECT_CALL(callbacks_, onResponse_(_));
+      pool_callbacks_[shard_count - 1]->onResponse(std::move(final_response));
+      
+    } else if ((command == "slowlog" && subcommand == "get") ||
+               (command == "config" && subcommand == "get")) {
+      // ArrayMergeAggregateResponseHandler
+      for (uint16_t i = 0; i < shard_count - 1; i++) {
+        auto array_response = std::make_unique<Common::Redis::RespValue>();
+        array_response->type(Common::Redis::RespType::Array);
+        std::vector<Common::Redis::RespValue> elements(1);
+        elements[0].type(Common::Redis::RespType::BulkString);
+        elements[0].asString() = "item" + std::to_string(i);
+        array_response->asArray().swap(elements);
+        pool_callbacks_[i]->onResponse(std::move(array_response));
+      }
+      
+      auto final_array = std::make_unique<Common::Redis::RespValue>();
+      final_array->type(Common::Redis::RespType::Array);
+      std::vector<Common::Redis::RespValue> final_elements(1);
+      final_elements[0].type(Common::Redis::RespType::BulkString);
+      final_elements[0].asString() = "final_item";
+      final_array->asArray().swap(final_elements);
+      
+      time_system_.setMonotonicTime(std::chrono::milliseconds(12));
+      EXPECT_CALL(store_, deliverHistogramToSinks(
+          Property(&Stats::Metric::name, stat_prefix + ".latency"), 12));
+      EXPECT_CALL(callbacks_, onResponse_(_));
+      pool_callbacks_[shard_count - 1]->onResponse(std::move(final_array));
+    }
+
+    // Verify stats were properly tracked
+    EXPECT_EQ(1UL, store_.counter(stat_prefix + ".total").value());
+    EXPECT_EQ(1UL, store_.counter(stat_prefix + ".success").value());
+  }
+
+  void testFailureConsistency(const std::string& command, const std::string& subcommand) {
+    std::vector<std::string> request_strings = {command};
+    if (!subcommand.empty()) {
+      request_strings.push_back(subcommand);
+    }
+    makeRequestToShard(2, request_strings, {}, false);
+    EXPECT_NE(nullptr, handle_);
+
+    std::string stat_prefix = "redis.foo.command." + command;
+    
+    // Test failure handling consistency
+    auto ok_response = std::make_unique<Common::Redis::RespValue>();
+    ok_response->type(Common::Redis::RespType::SimpleString);
+    ok_response->asString() = "OK";
+    pool_callbacks_[0]->onResponse(std::move(ok_response));
+    
+    time_system_.setMonotonicTime(std::chrono::milliseconds(10));
+    EXPECT_CALL(store_, deliverHistogramToSinks(
+        Property(&Stats::Metric::name, stat_prefix + ".latency"), 10));
+    EXPECT_CALL(callbacks_, onResponse_(_)); // Should get error response
+    pool_callbacks_[1]->onFailure(); // Trigger failure
+
+    // Verify error stats
+    EXPECT_EQ(1UL, store_.counter(stat_prefix + ".total").value());
+    EXPECT_EQ(1UL, store_.counter(stat_prefix + ".error").value());
+  }
+};
+
+TEST_F(ClusterScopeFrameworkConsistencyTest, AllHandlerTypesConsistent) {
+  // Test that all handler types follow the same framework patterns
+  std::vector<std::tuple<std::string, std::string, uint16_t>> test_cases = {
+    {"config", "set", 3},      // AllshardSameResponseHandler
+    {"flushall", "", 2},       // AllshardSameResponseHandler
+    {"slowlog", "len", 4},     // IntegerSumAggregateResponseHandler
+    {"slowlog", "get", 2},     // ArrayMergeAggregateResponseHandler
+    {"config", "get", 3}       // ArrayMergeAggregateResponseHandler
+  };
+
+  for (const auto& test_case : test_cases) {
+    testHandlerConsistency(std::get<0>(test_case), std::get<1>(test_case), std::get<2>(test_case));
+  }
+}
+
+TEST_F(ClusterScopeFrameworkConsistencyTest, FailureHandlingConsistent) {
+  // Test that all handler types handle failures consistently
+  std::vector<std::pair<std::string, std::string>> test_cases = {
+    {"config", "set"},
+    {"slowlog", "len"},
+    {"slowlog", "get"},
+    {"config", "get"}
+  };
+
+  for (const auto& test_case : test_cases) {
+    testFailureConsistency(test_case.first, test_case.second);
+  }
+}
+
+// Test memory management and resource cleanup
+class ClusterScopeMemoryManagementTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void testMemoryCleanup(const std::string& command, uint16_t shard_count) {
+    std::vector<std::string> request_strings = {command, "test"};
+    makeRequestToShard(shard_count, request_strings, {}, false);
+    EXPECT_NE(nullptr, handle_);
+
+    // Test cancellation cleans up properly
+    for (uint16_t i = 0; i < shard_count; i++) {
+      EXPECT_CALL(pool_requests_[i], cancel());
+    }
+    handle_->cancel();
+    
+    // After cancellation, the handle should be cleaned up
+    // No memory leaks should occur
+  }
+
+  void testResourceCleanupOnCompletion(const std::string& command, uint16_t shard_count) {
+    std::vector<std::string> request_strings = {command};
+    makeRequestToShard(shard_count, request_strings, {}, false);
+    EXPECT_NE(nullptr, handle_);
+
+    // Complete all responses to test normal cleanup
+    for (uint16_t i = 0; i < shard_count; i++) {
+      auto response = std::make_unique<Common::Redis::RespValue>();
+      response->type(Common::Redis::RespType::SimpleString);
+      response->asString() = "OK";
+      
+      if (i == shard_count - 1) {
+        EXPECT_CALL(callbacks_, onResponse_(_));
+      }
+      pool_callbacks_[i]->onResponse(std::move(response));
+    }
+    
+    // After completion, all resources should be cleaned up automatically
+  }
+};
+
+TEST_F(ClusterScopeMemoryManagementTest, CancellationCleanup) {
+  std::vector<std::pair<std::string, uint16_t>> test_cases = {
+    {"config", 3},
+    {"flushall", 5},
+    {"slowlog", 2}
+  };
+
+  for (const auto& test_case : test_cases) {
+    testMemoryCleanup(test_case.first, test_case.second);
+  }
+}
+
+TEST_F(ClusterScopeMemoryManagementTest, CompletionCleanup) {
+  std::vector<std::pair<std::string, uint16_t>> test_cases = {
+    {"flushall", 2},
+    {"config", 4}
+  };
+
+  for (const auto& test_case : test_cases) {
+    testResourceCleanupOnCompletion(test_case.first, test_case.second);
+  }
+}
+
+// Test error propagation through the framework
+class ClusterScopeErrorPropagationTest : public FragmentedRequestCommandHandlerTest {
+public:
+  void testErrorPropagation(const std::string& command, const std::string& error_scenario) {
+    std::vector<std::string> request_strings = {command, "test"};
+    makeRequestToShard(2, request_strings, {}, false);
+    EXPECT_NE(nullptr, handle_);
+
+    if (error_scenario == "upstream_failure") {
+      // Test upstream failure propagation
+      auto ok_response = std::make_unique<Common::Redis::RespValue>();
+      ok_response->type(Common::Redis::RespType::SimpleString);
+      ok_response->asString() = "OK";
+      pool_callbacks_[0]->onResponse(std::move(ok_response));
+      
+      EXPECT_CALL(callbacks_, onResponse_(_)); // Should receive error
+      pool_callbacks_[1]->onFailure();
+      
+    } else if (error_scenario == "error_response") {
+      // Test error response propagation
+      auto ok_response = std::make_unique<Common::Redis::RespValue>();
+      ok_response->type(Common::Redis::RespType::SimpleString);
+      ok_response->asString() = "OK";
+      pool_callbacks_[0]->onResponse(std::move(ok_response));
+      
+      auto error_response = Common::Redis::Utility::makeError("Redis error");
+      EXPECT_CALL(callbacks_, onResponse_(_)); // Should receive error
+      pool_callbacks_[1]->onResponse(std::move(error_response));
+      
+    } else if (error_scenario == "mixed_responses") {
+      // Test mixed response handling (for AllshardSameResponseHandler)
+      auto ok_response = std::make_unique<Common::Redis::RespValue>();
+      ok_response->type(Common::Redis::RespType::SimpleString);
+      ok_response->asString() = "OK";
+      pool_callbacks_[0]->onResponse(std::move(ok_response));
+      
+      auto different_response = std::make_unique<Common::Redis::RespValue>();
+      different_response->type(Common::Redis::RespType::SimpleString);
+      different_response->asString() = "DIFFERENT";
+      
+      EXPECT_CALL(callbacks_, onResponse_(_)); // Should receive error
+      pool_callbacks_[1]->onResponse(std::move(different_response));
+    }
+
+    // Verify error stats are properly tracked
+    std::string stat_prefix = "redis.foo.command." + command;
+    EXPECT_EQ(1UL, store_.counter(stat_prefix + ".total").value());
+    EXPECT_EQ(1UL, store_.counter(stat_prefix + ".error").value());
+  }
+};
+
+TEST_F(ClusterScopeErrorPropagationTest, UpstreamFailures) {
+  std::vector<std::string> commands = {"config", "flushall", "slowlog"};
+  for (const auto& command : commands) {
+    testErrorPropagation(command, "upstream_failure");
+  }
+}
+
+TEST_F(ClusterScopeErrorPropagationTest, ErrorResponses) {
+  std::vector<std::string> commands = {"config", "flushall", "slowlog"};
+  for (const auto& command : commands) {
+    testErrorPropagation(command, "error_response");
+  }
+}
+
+TEST_F(ClusterScopeErrorPropagationTest, MixedResponses) {
+  // Only test AllshardSameResponseHandler commands
+  std::vector<std::string> commands = {"config", "flushall"};
+  for (const auto& command : commands) {
+    testErrorPropagation(command, "mixed_responses");
+  }
+}
+
 } // namespace CommandSplitter
 } // namespace RedisProxy
 } // namespace NetworkFilters

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -3,7 +3,14 @@
 # will accept title case (e.g. lyft matches Lyft). Prefixes (e.g., un-) or suffixes (e.g. -ing)
 # are allowed for any otherwise correctly spelled word.
 
+Allshard
+FLUSHALL
+NUMPAT
+PUBSUB
+RANDOMKEY
+SLOWLOG
 addrlen
+flushdb
 itr
 STREQ
 htonl
@@ -1377,6 +1384,7 @@ struct
 structs
 subclassed
 subclasses
+subcommands
 subcomponent
 subdirectories
 subdirectory


### PR DESCRIPTION
Introduced ClusterScopeCmdRequest and RandomShardRequest to support keyless Redis commands.

Implemented response aggregation strategies via BaseClusterScopeResponseHandler:

AllshardSameResponseHandler → require identical responses (e.g., CONFIG SET, FLUSHALL).

IntegerSumAggregateResponseHandler → sum integers across shards (e.g., SLOWLOG LEN).

ArrayMergeAggregateResponseHandler → merge array responses (e.g., CONFIG GET, SLOWLOG GET).

Added ClusterResponseHandlerFactory to map commands/subcommands to proper strategy.

Extended SupportedCommands with:

Cluster-scope commands: config, flushall, flushdb, slowlog, script, unwatch.

Random-shard commands: cluster, randomkey.

Subcommand validation via commandSubcommandValidationMap().

Preserved local-only handlers (PING, ECHO, AUTH, TIME, etc.) and transaction flow.

Design patterns used: Strategy + Factory, Template Method, centralized policy/registry, fail-closed validation.

Tests added:

Handler behavior (same-response, integer sum, array merge).

Error paths (mismatched responses, upstream failure, invalid subcommands).

Routing integration and unsupported commands.

Memory cleanup, resource management, consistency across handler types.

How to extend:

Add command to cluster-scope or random-shard sets.

Map subcommands in commandSubcommandValidationMap().

If aggregation differs, implement a new BaseClusterScopeResponseHandler subclass.

Add test cases for success, error, and invalid scenarios.